### PR TITLE
Add Dependency checking

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -43,9 +43,11 @@ namespace GC\GamesCollector;
  * @since 1.1.0
  */
 function autoload_init() {
+	$cmb2_path = maybe_get_cmb2_path();
+
 	// Add in some specific includes and vendor libraries.
 	$files = [
-		__DIR__ . '/vendor/cmb2/cmb2/init.php',
+		$cmb2_path,
 		__DIR__ . '/inc/namespace.php',
 		__DIR__ . '/inc/functions.php',
 	];

--- a/plugin.php
+++ b/plugin.php
@@ -112,6 +112,12 @@ function init() {
 	// Load all the required files.
 	autoload_init();
 
+	// If CMB2 was not loaded, deactivate ourself.
+	if ( ! function_exists( 'cmb2_bootstrap' ) ) {
+		deactivate_plugins( plugin_basename( __FILE__ ) );
+		return;
+	}
+
 	// Register activation hook.
 	register_activation_hook( __FILE__, __NAMESPACE__ . '\\activate' );
 

--- a/plugin.php
+++ b/plugin.php
@@ -58,7 +58,17 @@ function autoload_init() {
 
 	// Check for extended cpts, load it if it hasn't already been loaded.
 	if ( ! function_exists( 'register_extended_post_type' ) ) {
-		$files[] = __DIR__ . '/vendor/johnbillion/extended-cpts/extended-cpts.php';
+		$plugin_vendor = __DIR__ . '/vendor/johnbillion/extended-cpts/extended-cpts.php';
+		$root_vendor = ABSPATH . '/vendor/johnbillion/extended-cpts/extended-cpts.php';
+		
+		// Check if extended cpts exists. If not, deactivate the plugin.
+		$exists = file_exists( $plugin_vendor ) || file_exists( $root_vendor );
+		if ( $exists ) {
+			$files[] = $exists ? $plugin_vendor : $root_vendor;
+		} else {
+			// If it's not loaded, deactivate the plugin.
+			deactivate_plugins( plugin_basename( __FILE__ ) );
+		}
 	}
 
 	// Autoload the namespaces.

--- a/plugin.php
+++ b/plugin.php
@@ -68,6 +68,42 @@ function autoload_init() {
 }
 
 /**
+ * Try to get the path to the CMB2 library.
+ *
+ * @since 1.3.6
+ */
+function maybe_get_cmb2_path() {
+	// If the CMB2 library is already loaded, we don't need to load it.
+	if ( function_exists( 'cmb2_bootstrap' ) ) {
+		return '';
+	}
+
+	// Maybe load from the vendor directory.
+	if ( file_exists( __DIR__ . '/vendor/cmb2/init.php' ) ) {
+		return __DIR__ . '/vendor/cmb2/init.php';
+	}
+
+	// Maybe load from the root /vendor directory.
+	if ( file_exists( ABSPATH . '/vendor/cmb2/init.php' ) ) {
+		return ABSPATH . '/vendor/cmb2/init.php';
+	}
+
+	// Was it installed as a plugin?
+	if ( file_exists( WP_PLUGIN_DIR . '/cmb2/init.php' ) ) {
+		// Activate the plugin.
+		activate_plugin( 'cmb2' );
+	}
+
+	// Last chance, maybe it's in the mu-plugins directory. If it's here, it should already be activated.
+	if ( file_exists( WPMU_PLUGIN_DIR . '/cmb2/init.php' ) ) {
+		return WPMU_PLUGIN_DIR . '/cmb2/init.php';
+	}
+
+	// If we got here, we couldn't find CMB2.
+	return '';
+}
+
+/**
  * Main initialization function.
  *
  * @since 1.1.0

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Games Collector
  * Plugin URI:  https://github.com/jazzsequence/games-collector
  * Description: Catalog all your tabletop (or other) games in your WordPress site and display a list of games in your collection.
- * Version:     1.3.4
+ * Version:     1.3.6
  * Author:      Chris Reynolds
  * Author URI:  https://jazzsequence.com
  * Donate link: https://paypal.me/jazzsequence

--- a/plugin.php
+++ b/plugin.php
@@ -47,10 +47,14 @@ function autoload_init() {
 
 	// Add in some specific includes and vendor libraries.
 	$files = [
-		$cmb2_path,
 		__DIR__ . '/inc/namespace.php',
 		__DIR__ . '/inc/functions.php',
 	];
+
+	// Only add CMB2 if we found it.
+	if ( $cmb2_path ) {
+		$files[] = $cmb2_path;
+	}
 
 	// Check for extended cpts, load it if it hasn't already been loaded.
 	if ( ! function_exists( 'register_extended_post_type' ) ) {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'jazzsequence/games-collector',
-        'pretty_version' => 'dev-develop',
-        'version' => 'dev-develop',
-        'reference' => '4deaa55152aa1117c0cf2d4fe3c183f1ee852a68',
+        'pretty_version' => 'dev-main',
+        'version' => 'dev-main',
+        'reference' => '0dd5d612c2011e2ce8a248ca927488078970e1e5',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -65,9 +65,9 @@
             'dev_requirement' => false,
         ),
         'jazzsequence/games-collector' => array(
-            'pretty_version' => 'dev-develop',
-            'version' => 'dev-develop',
-            'reference' => '4deaa55152aa1117c0cf2d4fe3c183f1ee852a68',
+            'pretty_version' => 'dev-main',
+            'version' => 'dev-main',
+            'reference' => '0dd5d612c2011e2ce8a248ca927488078970e1e5',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
addresses #72

whether we are closing that issue or not remains to be seen. this uses an alternate way of bailing the plugin that doesn't use plugin dependencies because CMB2 might not be installed as a plugin.