### PR TITLE
fix: remove v prefix from release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           VERSION=$(grep -m1 "Version:" plugin.php | sed 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if tag already exists
         id: tag_check


### PR DESCRIPTION
Tags should be `2.0.0` not `v2.0.0` to match the existing tag format (1.3.4, 1.3.5, 1.3.6).